### PR TITLE
HH-931 | fix: 다크 모드에서 글자가 안 보이는 오류 수정

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
     </style>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>


### PR DESCRIPTION
## 🥬 Todo - Requirements

- 다크 모드에서 글자가 안 보이는 오류 수정 완료

## 🥬 Key Changes

- styles.xml 수정
  
## 🥬 To Reviewers

- Theme.AppCompat.DayNight.NoActionBar의 경우 앱 내 text 등과 같이 시각화되는 것들에 대해 다크모드를 적용하게 되어 text가 흰 색이 되고, 그로 인해 안 보이는 거였다
- Theme.AppCompat.Light.NoActionBar로 변경해 앱이 라이트 모드를 사용하도록 변경했다.
