### PR TITLE
HH-931 | fix: 다크 모드에서 텍스트 및 DatePicker가 안 보이는 오류 수정

### DIFF
--- a/AnimatedViewBirthday.tsx
+++ b/AnimatedViewBirthday.tsx
@@ -358,7 +358,8 @@ const AnimatedViewBirthday = () => {
                           <DatePicker date={birthday}
                           onDateChange={(changedDate) => {
                               setBirthday(changedDate);}}
-                          mode='date'/>
+                          mode='date'
+                          theme='light'/>
                       </View>
                       <TouchableOpacity style={{alignItems:'center',}}
                       onPress={()=>{

--- a/ChangeProfile.tsx
+++ b/ChangeProfile.tsx
@@ -186,7 +186,8 @@ const ChangeProfile = () => {
                     <DatePicker date={birthday}
                     onDateChange={(changedDate) => {
                         setBirthday(changedDate);}}
-                    mode='date'/>
+                    mode='date'
+                    theme='light'/>
                 </View>
                 <TouchableOpacity style={{alignItems:'center',}}
                 onPress={async ()=>{

--- a/NotificationAdd.tsx
+++ b/NotificationAdd.tsx
@@ -66,7 +66,8 @@ const NotificationAdd = ({notificationAdded,checkNotificationAdded}:any) => {
                             }}>
                             <DatePicker date={date} onDateChange={(changedDate) => {
                             setDate(changedDate);
-                            }} mode="time"/>
+                            }} mode="time"
+                            theme="light"/>
                         </View>
                         <View style={{
                             paddingHorizontal: "15%",

--- a/NotificationView.tsx
+++ b/NotificationView.tsx
@@ -71,7 +71,8 @@ const NotificationView = ({id,time,timeChangedProp,checkTimeChanged}:any) => {
                             }}>
                             <DatePicker date={date} onDateChange={(changedDate) => {
                             setDate(changedDate);
-                            }} mode="time"/>
+                            }} mode="time"
+                            theme="light"/>
                         </View>
                         <View style={{
                             paddingHorizontal: "15%",

--- a/StampView.tsx
+++ b/StampView.tsx
@@ -167,7 +167,7 @@ const StampView = () => {
         <TouchableWithoutFeedback onPress={handleCloseTimeModal}>
           <View style={styles.timeModalContainer}>
             <Text style={styles.timeModalText}>기록 시간 변경하기</Text>
-            <DatePicker date={date} onDateChange={setDate} mode="date" />
+            <DatePicker date={date} onDateChange={setDate} mode="date" theme="light"/>
             <View style={styles.timeButtons}>
               <TouchableOpacity onPress={handleCloseTimeModal}>
                 <Text>취소</Text>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
     </style>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>


### PR DESCRIPTION
## 🥬 Todo - Requirements

- 다크 모드에서 텍스트 및 DatePicker가 안 보이는 오류 수정

<br>

## 🥬 Key Changes

- styles.xml
- 모든 DatePicker

<br>

## 🥬 To Reviewers

- <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">의 경우 text에 다크 모드를 적용해서 글자 색이 흰 색이 돼 배경이랑 겹쳐 안 보였습니다.
- <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">로 수정해 앱이 항상 라이트 모드이도록 변경했습니다.
- DatePicker의 경우 시스템의 모드를 가져와 auto로 보여주는 게 기본값이라 위의 수정으로 해결이 안 돼 일일이 theme를 light로 바꿔줬습니다.
