### PR TITLE
HH-893 | fix: stamp delete & add 로직 수정

### DIFF
--- a/StampView.tsx
+++ b/StampView.tsx
@@ -7,37 +7,17 @@ const StampView = () => {
   const [customStamps, setCustomStamps] = useState<ICustomStamp[]>([]);
 
   useEffect(() => {
-    const fetchedCustomStamps = getAllCustomStamps();
-    setCustomStamps(fetchedCustomStamps);
-  }, []);
-
-  const buttonsData = [
-    { id: 1, label: '기쁨', emotion: '😊'},
-    { id: 2, label: '슬픔', emotion: '😢'},
-    { id: 3, label: '화남', emotion: '😡'},
-    { id: 4, label: '놀람', emotion: '😱'},
-    { id: 5, label: '당황', emotion: '😳'},
-    { id: 6, label: '무표정', emotion: '😐'},
-    { id: 7, label: '우울', emotion: '😔'},
-    { id: 8, label: '불안', emotion: '😨'},
-    { id: 9, label: '짜증', emotion: '😤'},
-    { id: 10, label: '행복', emotion: '😁'},
-    { id: 11, label: '평온', emotion: '😌'},
-    { id: 12, label: '불만', emotion: '😒'},
-    { id: 13, label: '놀람', emotion: '😱'},
-    { id: 14, label: '당황', emotion: '😳'},
-    { id: 15, label: '무표정', emotion: '😐'},
-    { id: 16, label: '우울', emotion: '😔'},
-    { id: 17, label: '불안', emotion: '😨'},
-    { id: 18, label: '짜증', emotion: '😤'},
-    { id: 19, label: '행복', emotion: '😁'},
-    { id: 20, label: '평온', emotion: '😌'},
-    { id: 21, label: '불만', emotion: '😒'},
-    { id: 22, label: '놀람', emotion: '😱'},
-    { id: 23, label: '당황', emotion: '😳'},
-    { id: 24, label: '무표정', emotion: '😐'},
-    // 추가 버튼들...
-  ];
+    const stampsListener = (collection, changes) => {
+      setCustomStamps([...collection]);
+    };
+  
+    const stampsCollection = realm.objects('CustomStamp');
+    stampsCollection.addListener(stampsListener);
+  
+    return () => {
+      stampsCollection.removeListener(stampsListener);
+    }
+  }, []);  
 
   const [selectedEmotion, setSelectedEmotion] = useState(null);
   const [selectedEmotionLabel, setSelectedEmotionLabel] = useState(null);

--- a/src/localDB/document.ts
+++ b/src/localDB/document.ts
@@ -190,7 +190,9 @@ export function getCustomStampsByField(fieldName: keyof ICustomStamp, value: any
   return customStamp.map((customStamp) => customStamp)[0];
 }
 export function deleteCustomStamp(customStamp: ICustomStamp) {
-  realm.delete(customStamp);
+  realm.write(() => {
+    realm.delete(customStamp);
+  });
 }
 
 


### PR DESCRIPTION
## 🥬 Todo - Requirements
- 한 줄에 4개 미만일 때의 css 적용해야합니다.
- 이모지 변경시 텍스트 삭제가 아니라, 그냥 바로 수정되도록 해야합니다.

  
<br>

## 🥬 Key Changes
- what:
1) 라디오버튼 로직 수정
2) realm 수정
3) useEffect수정 등등

- why:
1) stampCount와 stampList 간에 중복처리로 인해 스탬프 삭제가 이상했음. 수정이 필요했음
2) 삭제가 안되었음
3) 추가가 안되었음
4) 삭제 & 추가가 localDB에 반영이 안되었음

- how:
1) realm에서 deleteCustomStamp에 realm.write 추가했습니다.
2) useEffect에서 getAllCustomStamps 함수를 비동기 작업 처리했습니다.
3) realm 데이터 변경 리스너를 추가하여 데이터 변경 시 이를 감지해서 다시 렌더링할 수 있도록 했습니다.
  
<br>

## 🥬 To Reviewers
@12novel30 
realm 파일 - document.ts에 미세한 수정사항이 있었습니다. 괜찮은지 확인이 필요합니다 !