### PR TITLE
Feat/hh 938 add stampcount to db

### DIFF
--- a/src/localDB/document.ts
+++ b/src/localDB/document.ts
@@ -179,6 +179,10 @@ export function updateCustomStampPushedCountById(id: string, number: number) {
   } else {
     console.warn("PushedStamp not found with the provided id:", id);
   }
+  // 예시 사용법입니다!
+  // console.log(repository.getAllCustomStamps()[0].id);
+  // repository.updateCustomStampPushedCountById('33456232-ac6e-43f5-8a55-9c05c23020e3', -3);
+  // console.log(repository.getAllCustomStamps()[0].pushedCnt);
 }
 
 export function updateCustomStamp(customStamp: ICustomStamp, updates: Partial<ICustomStamp>) {

--- a/src/localDB/document.ts
+++ b/src/localDB/document.ts
@@ -140,6 +140,8 @@ export interface ICustomStamp {
   stampName: string;
   emoji: string;
   createdAt: Date;
+  updatedAt: Date;
+  pushedCnt: number;
 }
 class CustomStamp extends Realm.Object {
   public static schema: Realm.ObjectSchema = {
@@ -150,16 +152,35 @@ class CustomStamp extends Realm.Object {
       stampName: { type: "string", optional: false },
       emoji: { type: "string", optional: false },
       createdAt: { type: "date", optional: false },
+      updatedAt: { type: "date", optional: false },
+      pushedCnt: { type: "int", optional: false },
     },
   };
 }
 export function createCustomStamp(values: any) {
+  var createDate = new Date();
   return realm.create('CustomStamp', {
     ...values,
     id: uuid.v4(), // 새로운 객체 생성 시 UUID 할당
-    createdAt: new Date(),
+    createdAt: createDate,
+    updatedAt: createDate,
+    pushedCnt: 0,
   });
 }
+export function updateCustomStampPushedCountById(id: string, number: number) {
+  // 스탬프 생성일 경우 number = 1
+  // 스탬프 삭제일 경우 number = -1
+  const customStamp = realm.objectForPrimaryKey<ICustomStamp>("CustomStamp", id);
+  if (customStamp) {
+    realm.write(() => {
+      customStamp.pushedCnt += number; // 'pushedCnt' 속성 1 증감
+      customStamp.updatedAt = new Date(); // 업데이트 시간 갱신
+    });
+  } else {
+    console.warn("PushedStamp not found with the provided id:", id);
+  }
+}
+
 export function updateCustomStamp(customStamp: ICustomStamp, updates: Partial<ICustomStamp>) {
   realm.write(() => {
     for (const key in updates) {
@@ -231,7 +252,7 @@ export function createPushedStamp(values: any) {
     ...values,
     id: uuid.v4(), // 새로운 객체 생성 시 UUID 할당
     createdAt: createDate,
-    updatedAt: createDate,  
+    updatedAt: createDate,
   });
 }
 export function updatePushedStamp(pushedStamp: IPushedStamp, updates: Partial<IPushedStamp>) {
@@ -346,6 +367,6 @@ export function deleteDailyReport(dailyReport: IDailyReport) {
 
 
 let realm = new Realm({ schema: [Notification, CustomStamp, PushedStamp, DailyReport],
-  schemaVersion: 4, });
+  schemaVersion: 5, });
 
 export default realm;

--- a/weeklyView/Weekly.tsx
+++ b/weeklyView/Weekly.tsx
@@ -178,7 +178,10 @@ const Weekly = () => {
   };
 
   // tmp_createDummyData(); 
-
+  
+  // console.log(repository.getAllCustomStamps()[0].id);
+  // repository.updateCustomStampPushedCountById('33456232-ac6e-43f5-8a55-9c05c23020e3', -3);
+  // console.log(repository.getAllCustomStamps()[0].pushedCnt);
   return (
     
     <View style={{backgroundColor: '#FAFAFA', flex:1}}>


### PR DESCRIPTION
## 🥬 Todo - Requirements
- [x] ICustomStamp에 updatedAt & pushedCnt 컬럼을 추가
- [x] realm 스키마 버전을 5로 변경
- [x] updateCustomStampPushedCountById 함수 작성

  
<br>

## 🥬 Key Changes
- 스탬프 id를 기준으로 pushedCnt를 +1,-1 하는 함수를 작성
- DB 버전을 5로 업그레이드 -> 충돌이 날 수도 있습니다 ..
  
<br>

## 🥬 To Reviewers
- @SayisMe document.tsx 에 해당 함수와 예시 사용법을 업로드해뒀습니다!
- TODO : 사용자가 앱을 업데이트했을 때 DB의 기존 기록이 사라지거나, 버전이 달라 마이그레이션 문제가 발생할 수도 있어서 이 부분은 나중에 해결하겠습니다